### PR TITLE
Fix trainer argument in multi node ddp example

### DIFF
--- a/Cloud Computing/Distributed Data Parallel (DDP)/multi_node.py
+++ b/Cloud Computing/Distributed Data Parallel (DDP)/multi_node.py
@@ -146,7 +146,8 @@ def main(
     # ... (rest of the main function)
     dataset, model, optimizer = load_train_objs()
     train_data = prepare_dataloader(dataset, batch_size)
-    trainer = Trainer(model, train_data, optimizer, rank, save_every)
+    # use the local rank as the gpu id when creating the trainer
+    trainer = Trainer(model, train_data, optimizer, local_rank, save_every)
     trainer.train(total_epochs)
     destroy_process_group()
 


### PR DESCRIPTION
## Summary
- fix undefined variable when instantiating `Trainer` in multi-node DDP script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687940d6cd848332b422cb22d28f7626